### PR TITLE
feat(kaspa): add signer interface for payouts

### DIFF
--- a/src/Miningcore/Blockchain/Kaspa/Configuration/KaspaPaymentProcessingConfigExtra.cs
+++ b/src/Miningcore/Blockchain/Kaspa/Configuration/KaspaPaymentProcessingConfigExtra.cs
@@ -18,4 +18,9 @@ public class KaspaPaymentProcessingConfigExtra
     /// Default: 2
     /// </summary>
     public int? MaxDegreeOfParallelPayouts { get; set; }
+
+    /// <summary>
+    /// Configuration options for the transaction signer
+    /// </summary>
+    public KaspaSignerConfig Signer { get; set; }
 }

--- a/src/Miningcore/Blockchain/Kaspa/Configuration/KaspaSignerConfig.cs
+++ b/src/Miningcore/Blockchain/Kaspa/Configuration/KaspaSignerConfig.cs
@@ -1,0 +1,14 @@
+namespace Miningcore.Blockchain.Kaspa.Configuration;
+
+public class KaspaSignerConfig
+{
+    /// <summary>
+    /// Type of signer implementation (e.g. "walletcore" or "sidecar")
+    /// </summary>
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Connection endpoint or additional parameters understood by the signer
+    /// </summary>
+    public string Endpoint { get; set; }
+}

--- a/src/Miningcore/Blockchain/Kaspa/IKaspaSigner.cs
+++ b/src/Miningcore/Blockchain/Kaspa/IKaspaSigner.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Miningcore.Blockchain.Kaspa.Configuration;
+
+namespace Miningcore.Blockchain.Kaspa;
+
+public class KaspaWalletBalance
+{
+    public decimal Pending { get; set; }
+    public decimal Available { get; set; }
+}
+
+public interface IKaspaSigner
+{
+    /// <summary>
+    /// Configure the signer using the provided configuration values
+    /// </summary>
+    Task ConfigureAsync(KaspaSignerConfig config, CancellationToken ct);
+
+    /// <summary>
+    /// Retrieve current wallet balance information
+    /// </summary>
+    Task<KaspaWalletBalance> GetBalanceAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Build and sign a transaction paying the given address the specified amount.
+    /// Returns the transaction id.
+    /// </summary>
+    Task<string> SendTransactionAsync(string address, decimal amount, string password, CancellationToken ct);
+}

--- a/src/Miningcore/Blockchain/Kaspa/KaspaPayoutHandler.cs
+++ b/src/Miningcore/Blockchain/Kaspa/KaspaPayoutHandler.cs
@@ -18,7 +18,6 @@ using Miningcore.Util;
 using Block = Miningcore.Persistence.Model.Block;
 using Contract = Miningcore.Contracts.Contract;
 using static Miningcore.Util.ActionUtils;
-using kaspaWalletd = Miningcore.Blockchain.Kaspa.KaspaWalletd;
 using kaspad = Miningcore.Blockchain.Kaspa.Kaspad;
 
 namespace Miningcore.Blockchain.Kaspa;
@@ -48,7 +47,7 @@ public class KaspaPayoutHandler : PayoutHandlerBase,
 
     protected readonly IComponentContext ctx;
     protected kaspad.KaspadRPC.KaspadRPCClient rpc;
-    protected kaspaWalletd.KaspaWalletdRPC.KaspaWalletdRPCClient walletRpc;
+    protected IKaspaSigner signer;
     private string network;
     private KaspaPoolConfigExtra extraPoolConfig;
     private KaspaPaymentProcessingConfigExtra extraPoolPaymentProcessingConfig;
@@ -73,16 +72,12 @@ public class KaspaPayoutHandler : PayoutHandlerBase,
             .Where(x => string.IsNullOrEmpty(x.Category))
             .ToArray();
         
-        // extract wallet daemon endpoints
-        var walletDaemonEndpoints = pc.Daemons
-            .Where(x => x.Category?.ToLower() == KaspaConstants.WalletDaemonCategory)
-            .ToArray();
-
-        if(walletDaemonEndpoints.Length == 0)
-            throw new PaymentException("Wallet-RPC daemon is not configured (Daemon configuration for kaspa-pools require an additional entry of category 'wallet' pointing to the wallet daemon)");
-
         rpc = KaspaClientFactory.CreateKaspadRPCClient(daemonEndpoints, extraPoolConfig?.ProtobufDaemonRpcServiceName ?? KaspaConstants.ProtobufDaemonRpcServiceName);
-        walletRpc = KaspaClientFactory.CreateKaspaWalletdRPCClient(walletDaemonEndpoints, extraPoolConfig?.ProtobufWalletRpcServiceName ?? KaspaConstants.ProtobufWalletRpcServiceName);
+
+        signer = ctx.Resolve<IKaspaSigner>() ?? throw new PaymentException("Kaspa transaction signer is not configured");
+
+        if(extraPoolPaymentProcessingConfig?.Signer != null)
+            await signer.ConfigureAsync(extraPoolPaymentProcessingConfig.Signer, ct);
         
         // we need a stream to communicate with Kaspad
         var stream = rpc.MessageStream(null, null, ct);
@@ -337,13 +332,11 @@ public class KaspaPayoutHandler : PayoutHandlerBase,
                 logger.Warn(()=> $"[{LogCategory}] Address {pair.Key} is not valid : {errorKaspaAddressUtility}");
         }
         
-        var callGetBalance = walletRpc.GetBalanceAsync(new kaspaWalletd.GetBalanceRequest());
-        var walletBalances = await Guard(() => callGetBalance.ResponseAsync,
+        var walletBalances = await Guard(() => signer.GetBalanceAsync(ct),
             ex=> logger.Debug(ex));
-        callGetBalance.Dispose();
-        
-        var walletBalancePending = (decimal) (walletBalances?.Pending == null ? 0 : walletBalances?.Pending) / KaspaConstants.SmallestUnit;
-        var walletBalanceAvailable = (decimal) (walletBalances?.Available == null ? 0 : walletBalances?.Available) / KaspaConstants.SmallestUnit;
+
+        var walletBalancePending = walletBalances?.Pending ?? 0m;
+        var walletBalanceAvailable = walletBalances?.Available ?? 0m;
         
         logger.Info(() => $"[{LogCategory}] Current wallet balance - Total: [{FormatAmount(walletBalancePending + walletBalanceAvailable)}] - Pending: [{FormatAmount(walletBalancePending)}] - Available: [{FormatAmount(walletBalanceAvailable)}]");
 
@@ -374,22 +367,13 @@ public class KaspaPayoutHandler : PayoutHandlerBase,
 
                 logger.Info(()=> $"[{LogCategory}] [{transferId}] Sending {FormatAmount(amount)} to {address}");
                 
-                var callSend = walletRpc.SendAsync(new kaspaWalletd.SendRequest {
-                    ToAddress = address.ToLower(),
-                    Amount = (ulong) (amount * KaspaConstants.SmallestUnit),
-                    Password = extraPoolPaymentProcessingConfig?.WalletPassword ?? null,
-                    UseExistingChangeAddress = true,
-                    IsSendAll = false,
-                });
-                var sendTransaction = await Guard(() => callSend.ResponseAsync,
-                    ex=> throw new PaymentException($"[{transferId}] kaspawalletd returned error: {ex}"));
-                callSend.Dispose();
+                var txId = await Guard(() => signer.SendTransactionAsync(address.ToLower(), amount, extraPoolPaymentProcessingConfig?.WalletPassword, ct),
+                    ex=> throw new PaymentException($"[{transferId}] signer returned error: {ex}"));
 
                 // check result
-                var txId = sendTransaction.TxIDs.First();
-
+                
                 if(string.IsNullOrEmpty(txId))
-                    throw new Exception($"[{transferId}] kaspawalletd did not return a transaction id!");
+                    throw new Exception($"[{transferId}] signer did not return a transaction id!");
                 else
                     logger.Info(() => $"[{LogCategory}] [{transferId}] Payment transaction id: {txId}");
 


### PR DESCRIPTION
## Summary
- introduce `IKaspaSigner` and config to allow pluggable Kaspa transaction signers
- switch payout handler to use signer for balances and transaction creation
- extend Kaspa payment processing config with signer parameters

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a9020d95508321b51fc3666dcb08ea